### PR TITLE
kontalk.org: show icons on large screens

### DIFF
--- a/kontalk.org/stylesheets/layout.css
+++ b/kontalk.org/stylesheets/layout.css
@@ -552,8 +552,8 @@ footer h3{
 ================================================== */
 
 	@media only screen and (min-width: 960px) {
-		#info .info-box .icon i{
-			display: none;
+		.container .eight.columns {
+				width: 420px;
 		}
 	}
 


### PR DESCRIPTION
On large screen (over  960px) show icons in and fix related text column width
